### PR TITLE
Use ActiveRecord::Migration.migrations_pathS

### DIFF
--- a/lib/grape/app/tasks/databases.rake
+++ b/lib/grape/app/tasks/databases.rake
@@ -26,10 +26,12 @@ namespace :db do
   task migration: :environment do
     abort "No NAME specified. Example usage: `rake db:migration NAME=create_widgets`" unless ENV["NAME"]
 
-    name = ENV["NAME"]
-    path = File.join(ActiveRecord::Migrator.migrations_path, "#{Time.now.utc.strftime('%Y%m%d%H%M%S')}_#{name}.rb")
+    migrations_path = ActiveRecord::Migrator.migrations_paths.first
 
-    FileUtils.mkdir_p(ActiveRecord::Migrator.migrations_path)
+    name = ENV["NAME"]
+    path = File.join(migrations_path, "#{Time.now.utc.strftime('%Y%m%d%H%M%S')}_#{name}.rb")
+
+    FileUtils.mkdir_p(migrations_path)
     File.write path, <<-MIGRATION.strip_heredoc
       class #{name.camelize} < ActiveRecord::Migration
         def change


### PR DESCRIPTION
Newer ActiveRecord does not have single `migration_path`, has only `migrations_paths`: http://www.rubydoc.info/gems/activerecord/5.1.3/ActiveRecord/Migrator#migrations_paths-class_method

Seems to be removed in 5.xx, still present in 4.x.x. Also, 4.x.x has http://www.rubydoc.info/gems/activerecord/4.0.0/ActiveRecord/Migrator#migrations_paths-class_method this method, so this change should be safe.
